### PR TITLE
Clean split names before exporting XML

### DIFF
--- a/packages/celer-web-app/CHANGELOG.md
+++ b/packages/celer-web-app/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Change Log
 This is the change log for celer-web-app
 
-## `4.1.1` - `05-11-2022` `LATEST`
+## `4.1.2` - `05-19-2022` `LATEST`
+- Bug fix: Clean split names before writing them to XML
+
+## `4.1.1` - `05-11-2022`
 - `u` routes are disabled
 - Add copy-paste and local file loading from home page
 - Home page link in menu

--- a/packages/celer-web-app/experiments.json
+++ b/packages/celer-web-app/experiments.json
@@ -4,5 +4,6 @@
     "ExportCustomSplits": true,
     "CleanSplitNames": true,
     "NoTrackDocPos": true,
+    "WarnNegativeVar": false,
     "PigeonMap": false
 }

--- a/packages/celer-web-app/experiments.json
+++ b/packages/celer-web-app/experiments.json
@@ -1,8 +1,8 @@
 {
     "EnhancedScrollTrackerEnabled": false,
     "MapSyncToDocScrollEnabled": false,
-    "ExportSplits": false,
     "ExportCustomSplits": true,
+    "CleanSplitNames": true,
     "NoTrackDocPos": true,
     "PigeonMap": false
 }

--- a/packages/celer-web-app/package.json
+++ b/packages/celer-web-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "celer-web-app",
   "homepage": "https://celer.itntpiston.app",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.16.0",

--- a/packages/celer-web-app/src/app/AppState.tsx
+++ b/packages/celer-web-app/src/app/AppState.tsx
@@ -107,6 +107,7 @@ export class AppStateProvider extends React.Component<EmptyObject, AppState> {
 	}
 
 	private setRouteAssembly(routeAssembly: RouteAssemblySection[], metadata: RouteMetadata, config: RouteConfig): void {
+		routeEngine.warnNegativeNumberEnable = this.context("WarnNegativeVar");
 		const docLines = routeEngine.compute(routeAssembly);
 
 		const [mapIcons, mapLines] = mapEngine.compute(docLines);

--- a/packages/celer-web-app/src/core/engine/engine.ts
+++ b/packages/celer-web-app/src/core/engine/engine.ts
@@ -40,6 +40,7 @@ const ROMAN_NUMERAL = ["","I","II","III","IV","V","VI","VII","VIII","IX","X","XI
 export class RouteEngine{
 	// Engine configuration
 	private splitSetting: SplitTypeSetting<boolean> =defaultSplitSetting;
+	public warnNegativeNumberEnable = false;
 
 	private sectionNumber = 0;
 	private lineNumber = 0;
@@ -170,6 +171,7 @@ export class RouteEngine{
 	private computeNonBannerStep(data: RouteAssembly, output: DocLine[]): void {
 		let step: string | undefined = undefined;
 		const error = new Set<string>();
+		const warning: string[] = [];
 
 		let galeText = "?";
 		if(data.gale){
@@ -186,6 +188,14 @@ export class RouteEngine{
 		if(data.isStep){
 			step = this.step;
 			this.incStep();
+		}
+		if(this.warnNegativeNumberEnable && data.variableChange){
+			for (const key in data.variableChange){
+				if(this.variables[key] < 0){
+					warning.push(`Variable "${key}" has a negative value`);
+				}
+			}
+			
 		}
 		
 		const common = {
@@ -298,6 +308,15 @@ export class RouteEngine{
 			output.push({
 				lineType: "DocLineBanner",
 				bannerType: BannerType.Error,
+				showTriangle: true,
+				text: new TypedStringSingle({content: e, type: StringType.Normal})
+			});
+		});
+
+		warning.forEach(e=>{
+			output.push({
+				lineType: "DocLineBanner",
+				bannerType: BannerType.Warning,
 				showTriangle: true,
 				text: new TypedStringSingle({content: e, type: StringType.Normal})
 			});

--- a/packages/celer-web-app/src/core/external/livesplit.ts
+++ b/packages/celer-web-app/src/core/external/livesplit.ts
@@ -34,13 +34,13 @@ export const toLiveSplitEncodedImage = (webpackImageData: string):string => {
 	return cDataString;
 };
 
-export const createLiveSplitFile = (lines: DocLine[], enableSubsplits: boolean, formatter: (variables: MapOf<number>, splitType: SplitType, lineText: string)=>string|undefined): string => {
+export const createLiveSplitFile = (lines: DocLine[], enableSubsplits: boolean, formatter: (variables: MapOf<number>, splitType: SplitType, lineText: string)=>string|undefined, cleanInput: boolean): string => {
 	const header = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Run version=\"1.7.0\"><GameIcon/><GameName/><CategoryName/><LayoutPath/><Metadata><Run id=\"\"/><Platform usesEmulator=\"False\"/><Region/><Variables /></Metadata><Offset>00:00:00</Offset><AttemptCount>0</AttemptCount><AttemptHistory/><Segments>";
 	const footer = "</Segments><AutoSplitterSettings/></Run>";
-	return `${header}${createSegmentTags(lines, enableSubsplits, formatter)}${footer}`;
+	return `${header}${createSegmentTags(lines, enableSubsplits, formatter, cleanInput)}${footer}`;
 };
 
-const createSegmentTags = (lines: DocLine[], enableSubsplits: boolean, formatter: (variables: MapOf<number>, splitType: SplitType, lineText: string)=>string|undefined): string => {
+const createSegmentTags = (lines: DocLine[], enableSubsplits: boolean, formatter: (variables: MapOf<number>, splitType: SplitType, lineText: string)=>string|undefined, cleanInput: boolean): string => {
 	const splitNames: string[] = [];
 	const splitIcons: string[] = [];
 	let sectionName = "";
@@ -76,10 +76,15 @@ const createSegmentTags = (lines: DocLine[], enableSubsplits: boolean, formatter
 		}
 	}
 
-	return splitNames.map((name, i)=>createSegmentTag(name, splitIcons[i])).join("");
+	return splitNames.map((name, i)=>createSegmentTag(name, splitIcons[i], cleanInput)).join("");
 };
 
-const createSegmentTag = (splitName: string, icon: string): string =>{
+const createSegmentTag = (splitName: string, icon: string, cleanInput: boolean): string =>{
 	const cData = toLiveSplitEncodedImage(icon);
-	return `<Segment><Name>${splitName}</Name><Icon>${cData}</Icon><SplitTimes><SplitTime name="Personal Best" /></SplitTimes><BestSegmentTime /><SegmentHistory /></Segment>`;
+	
+	return `<Segment><Name>${cleanInput ? cleanString(splitName) : splitName}</Name><Icon>${cData}</Icon><SplitTimes><SplitTime name="Personal Best" /></SplitTimes><BestSegmentTime /><SegmentHistory /></Segment>`;
+};
+
+const cleanString = (input: string): string => {
+	return input.replaceAll("&", "&amp;").replaceAll("\"", "&quot;").replaceAll("'", "&apos;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 };

--- a/packages/celer-web-app/src/data/util/version.ts
+++ b/packages/celer-web-app/src/data/util/version.ts
@@ -1,1 +1,1 @@
-export const WebAppVersion = "4.1.1";
+export const WebAppVersion = "4.1.2";

--- a/packages/celer-web-app/src/ui/frames/AppFrame.tsx
+++ b/packages/celer-web-app/src/ui/frames/AppFrame.tsx
@@ -40,8 +40,8 @@ export const AppFrame: React.FC<EmptyObject> = ()=>{
 	const [showMenu, setShowMenu] = useState(false);
 	const [contextMenuRef, setContextMenuRef] = useState<React.RefObject<HTMLDivElement> | undefined>(undefined);
 
-	const downloadSplitsEnabled = useAppExperiment("ExportSplits");
 	const downloadCustomSplitsEnabled = useAppExperiment("ExportCustomSplits");
+	const cleanSplitNamesEnabled = useAppExperiment("CleanSplitNames");
    
 	let errorCount = 0;
 	docLines.forEach(l=>{
@@ -119,39 +119,6 @@ export const AppFrame: React.FC<EmptyObject> = ()=>{
 							<MenuItemSubmenu selected={splitSettingsMenuItemRef === contextMenuRef} text="Split Settings..." hover={function (): void {
 								setContextMenuRef(splitSettingsMenuItemRef);
 							} } ref={splitSettingsMenuItemRef}/>
-							{downloadSplitsEnabled && <MenuItem text="(Deprecated) Download AS Splits" action={function (): void {
-								const splitContent = createLiveSplitFile(docLines, false, (variables, splitType, lineText)=>{
-									const prefixnumber = (i: number):string => {
-										if (i >= 100) {return String(i);}
-										if(i>=10) {return "0"+String(i);}
-										return "00"+String(i);
-									};
-									let name: string | undefined = undefined;
-									if(splitType === SplitType.Shrine){
-										name = "[" + prefixnumber(variables.SRN) + "] " + lineText;
-									}else if (splitType === SplitType.Warp){
-										name = lineText + " Again";
-									}else if (splitType !== SplitType.None){
-										name = lineText;
-									}
-									return name;
-								});
-								saveAs(splitContent, "celer-splits.lss");
-							} }/>}
-							{downloadSplitsEnabled && <MenuItem text="(Deprecated) Download Hundo Splits" action={function (): void {
-								const splitContent = createLiveSplitFile(docLines, false, (variables, splitType, lineText)=>{
-									let name: string | undefined = undefined;
-									if(splitType === SplitType.Shrine){
-										name = String(variables.KRK) + " - " + lineText;
-									}else if (splitType === SplitType.Warp){
-										name = lineText + " Again";
-									}else if (splitType === SplitType.Tower || splitType === SplitType.UserDefined){
-										name = lineText;
-									}
-									return name;
-								});
-								saveAs(splitContent, "celer-splits-hundo.lss");
-							} }/>}
 							{downloadCustomSplitsEnabled && <MenuItem text="Download Splits (.lss)" action={ () => {
 								const interpolationFunctions: SplitTypeConfig<(variables: MapOf<number|string>)=>string> = {};
 								if(config["split-format"]){
@@ -180,7 +147,7 @@ export const AppFrame: React.FC<EmptyObject> = ()=>{
 										return processed;
 									}
 									return lineText;
-								});
+								}, cleanSplitNamesEnabled);
 								saveAs(splitContent, (metadata.name || "celer-splits").replaceAll(" ", "-")+".lss");
 							} }/>}
 							{bundle && <MenuItem text="Download bundle.json" action={function (): void {


### PR DESCRIPTION
Replace the XML control characters with their proper escapes