### PR TITLE
Update comments in koroks.csv

### DIFF
--- a/packages/celer-code-generator/src/koroks.csv
+++ b/packages/celer-code-generator/src/koroks.csv
@@ -4,19 +4,19 @@ A02,3326.96,309.81,-3589.20,RockCircle
 A03,3455.61,314.14,-3581.87,LiftRockBoulder
 A04,3813.45,255.99,-3419.22,FlowerCount
 A05,3152.59,170.16,-3328.34,Race,
-A06,3496.16,255.92,-3374.29,LiftRockSlab,1 Stasis
+A06,3496.16,255.92,-3374.29,LiftRockSlab
 A07,3779.70,275.42,-3361.51,BoulderGolf
 A08,4422.96,115.15,-3340.21,LiftRockRubble
-A09,4815.50,105.73,-3300.24,LiftRockSlab,1 Stasis
-A10,3178.98,176.40,-3073.66,LiftRockSlab,1 Stasis
+A09,4815.50,105.73,-3300.24,LiftRockSlab
+A10,3178.98,176.40,-3073.66,LiftRockSlab
 A11,3350.10,175.02,-3079.83,LiftRockTree
-A12,3572.84,205.91,-3046.93,Balloon,Static under hanging cliff
+A12,3572.84,205.91,-3046.93,Balloon,Hanging under cliff
 A13,3995.79,292.52,-3147.58,LiftRockLeaves
-A14,4344.05,363.38,-3178.36,Race,.dir(.E)
+A14,4344.05,363.38,-3178.36,Race
 A15,4428.83,352.26,-3182.90,LiftRock
 A16,4503.65,379.21,-3164.38,Confetti
 A17,4817.19,106.12,-3094.21,FlowerCount,Start top of guardian
-A18,3736.66,147.37,-2884.98,AcornLog,Shoot midair
+A18,3736.66,147.37,-2884.98,AcornLog
 A19,4103.20,232.56,-2832.40,FlowerCount
 A20,3436.59,155.19,-2533.65,BlockPuzzle
 A21,3726.79,127.29,-2677.46,LiftRock,Side of spring
@@ -26,13 +26,13 @@ A24,4508.73,106.40,-2643.60,BlockPuzzle
 A25,3372.04,271.94,-2315.19,Confetti,Top of tree
 A26,3732.84,139.54,-2423.21,BlockPuzzle
 A27,3877.54,178.84,-2371.86,LightChase
-A28,4181.04,220.80,-2540.40,Race,Ordinal DEFUSE
-A29,4338.09,170.55,-2438.51,Balloon,1 BA middle
+A28,4181.04,220.80,-2540.40,Race
+A29,4338.09,170.55,-2438.51,Balloon
 A30,3244.91,265.87,-2000.30,LightChase
 A31,3479.96,280.77,-2077.34,LiftRockLeaves
-A32,3662.78,273.67,-2067.31,MatchTree,Closest tree
+A32,3662.78,273.67,-2067.31,MatchTree
 A33,4530.94,106.98,-2098.37,LiftRockLeaves
-A34,4098.31,232.81,-1756.46,RockCircle,Rock in bush
+A34,4098.31,232.81,-1756.46,RockCircle
 A35,4634.40,139.70,-1840.94,FlowerChase
 A36,4691.70,136.71,-1777.33,BlockPuzzle
 A37,3709.39,204.17,-1683.44,LiftRock,Top of stone structure
@@ -47,12 +47,12 @@ A45,3112.55,426.00,-1295.32,RockCircle
 A46,3407.36,442.76,-1278.32,LiftRockDoor
 A47,3882.54,356.53,-1340.01,OfferApple
 A48,4104.55,282.08,-1350.66,FlowerCount
-A49,4038.20,329.62,-1254.87,MatchTree,Right tree
-A50,3010.15,346.43,-1204.24,LiftRockSlab,Broken column. Stasis MAX
-A51,3726.30,331.25,-1129.71,Basketball,GG rock throw
+A49,4038.20,329.62,-1254.87,MatchTree
+A50,3010.15,346.43,-1204.24,LiftRockSlab
+A51,3726.30,331.25,-1129.71,Basketball
 A52,3604.77,334.48,-1008.63,LiftRock,Below bridge
-A53,4239.35,409.88,-998.25,MatchTree,Middle
-A54,3960.61,378.52,-858.58,Balloon,Pre BT left of tree
+A53,4239.35,409.88,-998.25,MatchTree
+A54,3960.61,378.52,-858.58,Balloon
 A55,4042.21,351.56,-661.96,LiftRockBoulder
 A56,4332.91,406.96,-696.63,LightChase
 A57,4144.26,406.69,-595.96,Confetti,Top of tree
@@ -61,16 +61,16 @@ C02,589.77,121.48,-1107.12,BlockPuzzle
 C03,-670.08,119.11,-932.68,BlockPuzzle
 C04,178.54,134.04,-940.02,LiftRock,In fountain
 C05,319.65,137.19,-962.06,AcornTree,In tree
-C06,506.90,141.81,-882.61,LilyPads,No Drown
+C06,506.90,141.81,-882.61,LilyPads
 C07,-941.41,133.35,-817.63,AcornFlying
-C08,-681.31,122.38,-860.62,OfferShield,Leave shield
+C08,-681.31,122.38,-860.62,OfferShield
 C09,696.30,217.99,-824.38,Confetti,Top of tree
-C10,292.18,117.21,-724.08,Basketball,2 Cryo blocks
+C10,292.18,117.21,-724.08,Basketball
 C11,613.41,183.51,-743.37,LiftRock,Inside hollow tree
 C12,840.40,236.28,-692.47,LiftRock,In tree stump on peak
-C13,1265.17,116.40,-707.25,Basketball,Cryo block near rocks
+C13,1265.17,116.40,-707.25,Basketball
 C14,-935.20,167.84,-641.24,LiftRock
-C15,-609.56,119.00,-682.30,LilyPads,Cryo block
+C15,-609.56,119.00,-682.30,LilyPads
 C16,-267.21,139.86,-610.18,Acorn,Under bridge
 C17,85.54,138.13,-634.97,LiftRockLeaves
 C18,396.08,115.50,-625.56,LightChase
@@ -82,27 +82,27 @@ C23,504.45,123.33,-493.46,AcornHanging,Below bridge
 C24,-1035.08,150.22,-446.22,LiftRock,On small hill near bridge
 C25,-803.95,138.07,-403.12,LiftRock
 C26,-663.30,146.77,-432.60,Balloon,In tree
-C27,-253.82,141.72,-425.72,Race,Aim at castle door turn
+C27,-253.82,141.72,-425.72,Race
 C28,86.23,138.81,-412.08,LiftRockDoor
 C29,97.63,181.01,-429.80,Confetti,Top of flagpole
 C30,-886.65,129.25,-274.04,LiftRockRubble,Next to broken house
 C31,-548.5,140.88,-229.52,LiftRock,On wall
 C32,-254.35,146.84,-264.41,ShootEmblem,Castle Town Gate
-C33,-161.75,147.43,-262.04,Balloon,On out wall
-C34,623.24,123.53,-194.76,MatchTree,Left tree
+C33,-161.75,147.43,-262.04,Balloon,On outer wall
+C34,623.24,123.53,-194.76,MatchTree
 C35,-239.38,139.77,-112.59,LiftRock,On pillar
 C36,-1336.88,122.55,249.66,LiftRock
 C37,-1336.35,117.12,366.61,BlockPuzzle
 C38,-1155.96,137.33,245.12,FlowerChase
 C39,-868.50,187.17,219.11,Confetti,Top of flag pole
-C40,-728.06,154.69,134.77,LightChase,Same Forest
+C40,-728.06,154.69,134.77,LightChase
 C41,-710.25,158.35,99.93,AcornTree
-C42,-516.95,154.04,97.79,Balloon,Shoot midair
+C42,-516.95,154.04,97.79,Balloon
 C43,-427.28,135.84,150.92,AcornFlying
 C44,25.66,148.47,147.48,LiftRock
 C45,384.26,154.17,135.36,LiftRock,On hill
 C46,806.57,116.89,24.09,LiftRock,Under bridge
-C47,-1127.28,145.96,414.31,LilyPads,Cryo
+C47,-1127.28,145.96,414.31,LilyPads
 C48,-737.40,125.85,333.75,LiftRock,Between 2 rocks
 C49,-363.24,131.73,396.94,AcornHanging,Wagon next to tree
 C50,142.93,128.21,296.02,FlowerCount,Chaos Ranch
@@ -110,11 +110,11 @@ C51,627.03,130.94,182.30,BoulderCircle
 C52,-1313.94,116.17,622.86,LiftRock,In well
 C53,-1020.38,201.02,559.81,OfferApple
 C54,-512.75,170.26,550.62,Confetti,Top of flagpole
-C55,-122.09,128.79,594.00,LightChase,Forest left of guardian
+C55,-122.09,128.79,594.00,LightChase
 C56,322.06,127.50,525.00,OfferApple
 C57,-1249.55,125.52,730.67,AcornTree
 C58,-1439.60,125.50,846.66,TreeStump
-C59,-1512.68,117.38,908.66,Basketball,Cryo block
+C59,-1512.68,117.38,908.66,Basketball
 C60,-1106.93,139.42,905.26,BlockPuzzle
 C61,-1009.46,130.11,932.03,RockCircle
 C62,-749.92,132.90,892.21,LightChase
@@ -122,87 +122,87 @@ C63,-644.58,146.21,876.11,FlowerChase
 C64,-133.70,143.35,945.03,LightChase
 C65,225.38,173.64,872.04,AcornTree
 C66,-1356.69,140.95,1002.41,RockCircle
-C67,-1154.35,132.86,964.63,LiftRock,On ledge (Hard to see)
+C67,-1154.35,132.86,964.63,LiftRock,On ledge (hard to see)
 C68,-1134.46,143.84,1030.47,AcornHanging,On bridge
 C69,-599.94,138.02,1071.81,AcornHanging,From tree
-C70,-106.45,153.33,1047.96,RockCircle,3
+C70,-106.45,153.33,1047.96,RockCircle
 C71,39.26,140.77,1034.49,LiftRockTree
-C72,-1370.34,174.22,1165.82,AcornFlying,BT
-C73,-1190.02,174.95,1116.74,Race,SQ High
+C72,-1370.34,174.22,1165.82,AcornFlying
+C73,-1190.02,174.95,1116.74,Race
 C74,-1149.91,218.28,1204.10,LiftRock,Top of Coliseum
-C75,-425.27,131.0,1189.34,LilyPads,No Drown
+C75,-425.27,131.0,1189.34,LilyPads
 C76,-466.41,137.21,1279.38,LiftRockLeaves
 C77,295.58,135.22,1204.79,Balloon
 C78,-1314.29,139.19,1257.33,LiftRock
 C79,-1224.68,299.79,1358.41,LiftRock
-C80,-1280.39,284.68,1384.89,AcornLog,Shoot midair
+C80,-1280.39,284.68,1384.89,AcornLog
 C81,-1057.31,167.53,1327.52,LightChase,In ruins
 C82,-770.02,135.06,1380.97,LightChase
-C83,-653.64,159.13,1390.28,Balloon,Rotate to the left
-C84,69.30,121.17,1438.00,AcornFlying,Shoot hard one in non BT
+C83,-653.64,159.13,1390.28,Balloon
+C84,69.30,121.17,1438.00,AcornFlying
 C85,-1666.66,249.27,1393.96,LiftRockTree
 C86,-1728.58,144.39,1478.86,LiftRock
 C87,-1583.93,68.69,1579.69,Basketball
-C88,-1746.91,71.0,1831.09,LilyPads,Cryo Block
-C89,-1491.53,68.49,1832.24,Basketball,GG throw
+C88,-1746.91,71.0,1831.09,LilyPads
+C89,-1491.53,68.49,1832.24,Basketball
 D01,954.40,116.27,942.46,LiftRock,Island below
-D02,1775.80,219.04,963.60,LilyPads,Impa house. Cryo
+D02,1775.80,219.04,963.60,LilyPads,Next to Impa's house
 D03,1807.03,220.44,992.20,OfferApple
 D04,1793.89,258.89,1052.82,LiftRock,Ledge
 D05,1798.33,230.96,1078.17,ShootEmblem
 D06,1957.25,248.06,1062.05,ShootEmblem
-D07,2163.89,460.62,1034.73,LiftRock,2nd Peak
+D07,2163.89,460.62,1034.73,LiftRock
 D08,1939.51,269.11,1110.93,LiftRock,On ledge
-D09,1676.10,324.63,1157.93,MatchTree,Closest to peak
-D10,1739.30,413.37,1186.67,LiftRock,2nd Peak
+D09,1676.10,324.63,1157.93,MatchTree
+D10,1739.30,413.37,1186.67,LiftRock
 D11,1933.25,376.73,1220.96,LiftRock,Peak
 D12,2058.50,244.81,1208.55,BlockPuzzle
-D13,516.10,127.02,1167.10,LiftRockTree,3rd big tree N of open rock
+D13,516.10,127.02,1167.10,LiftRockTree
 D14,337.14,120.05,1271.06,AcornHanging,From bridge
 D15,715.11,166.34,1327.02,TreeStump,Edge of forest
 D16,1040.55,121.35,1318.15,LiftRock,Small island
 D17,1293.44,273.69,1331.36,LiftRockTree
-D18,1553.54,119.0,1297.18,LilyPads,No Drown
-D19,1638.96,116.47,1376.28,Basketball,no GG
-D20,1750.43,116.39,1544.68,Basketball,GG a rock down
+D18,1553.54,119.0,1297.18,LilyPads
+D19,1638.96,116.47,1376.28,Basketball
+D20,1750.43,116.39,1544.68,Basketball
 D21,2207.28,192.59,1373.48,Confetti,Top of tree
 D22,318.15,115.38,1397.90,LiftRockBoulder
 D23,518.62,131.00,1475.52,AcornFlying
-D24,668.64,135.47,1468.29,BoulderGolf,Surf down after bomb
-D25,788.83,145.87,1471.35,JumpFence,Summon Horse
+D24,668.64,135.47,1468.29,BoulderGolf
+D25,788.83,145.87,1471.35,JumpFence
 D26,87.01,164.54,1585.09,Confetti,Top of flagpole
 D27,232.20,115.35,1601.41,LiftRock,Under bridge
 D28,671.09,180.86,1638.37,Confetti,Top of flagpole
 D29,850.50,115.39,1623.99,LiftRock,On island
 D30,1376.52,327.85,1680.34,OfferApple
 D31,54.98,146.90,1758.55,BoulderGolf
-D32,112.31,116.67,1709.78,Basketball,GG throw p close
+D32,112.31,116.67,1709.78,Basketball
 D33,178.96,116.68,1719.98,BlockPuzzle
 D34,225.30,121.99,1705.66,LiftRock
 D35,312.68,180.27,1766.79,Balloon
 D36,516.76,167.24,1788.16,FlowerChase
 D37,644.18,116.81,1763.26,BoulderGolf
 D38,704.98,116.75,1796.56,LiftRock,In cave
-D39,1049.23,115.87,1783.27,FlowerChase,Across River
+D39,1049.23,115.87,1783.27,FlowerChase,Across river
 D40,1258.45,492.11,1851.12,LiftRock
 D41,1517.27,400.24,1850.08,BoulderGolf
 D42,1748.57,140.69,1921.65,Confetti,Top of stable
 D43,-189.70,121.28,1835.39,FlowerCount,In cave
 D44,5.32,207.82,1897.89,LiftRock
 D45,160.04,150.43,1942.17,Confetti
-D46,551.57,182.90,1903.50,MatchTree,Right tree
+D46,551.57,182.90,1903.50,MatchTree
 D47,868.27,142.61,1902.03,Balloon
 D48,1101.69,224.28,1889.53,LiftRock,Upper level
 D49,1245.11,541.34,1942.17,OfferApple
 D50,815.22,202.72,2089.43,LiftRockSlab
 D51,1877.42,132.53,2051.32,LiftRockTree,Big tree
 D52,2054.82,153.24,2092.72,Balloon
-D53,2484.82,119.0,2103.39,LilyPads,Put cryo
+D53,2484.82,119.0,2103.39,LilyPads
 D54,-115.48,186.84,2303.39,Torch
 D55,1682.65,201.46,2327.61,LiftRock,On ledge high
-D56,1886.18,147.40,2418.73,LiftRock,In Tree Stump
-D57,2303.51,281.29,2375.13,LilyPads,No Drown
-D58,2366.56,221.70,2303.49,AcornFlying,Bomb Arrow
+D56,1886.18,147.40,2418.73,LiftRock,In tree stump
+D57,2303.51,281.29,2375.13,LilyPads
+D58,2366.56,221.70,2303.49,AcornFlying
 D59,1936.54,134.27,2564.50,LiftRock,Bottom of waterfall
 E01,1615.10,207.95,-3661.03,LiftRockLeaves
 E02,2087.11,318.25,-3573.55,BlockPuzzle
@@ -217,179 +217,179 @@ E10,1885.78,513.93,-2749.10,Balloon
 E11,2060.97,580.31,-2757.41,RockCircle
 E12,3322.94,379.46,-2803.06,BlockPuzzle
 E13,1658.13,554.58,-2564.87,LiftRock
-E14,1725.34,607.05,-2553.93,Race,SQ
-E15,1593.87,543.91,-2475.24,Confetti,Inside agreeGe
+E14,1725.34,607.05,-2553.93,Race
+E15,1593.87,543.91,-2475.24,Confetti,Inside Goron's mouth
 E16,1865.55,533.93,-2465.04,Confetti,Top of skeleton
-E17,1867.81,511.00,-2400.63,Race,Glide over
-E18,1647.23,521.04,-2244.46,RockCircle,GG over
+E17,1867.81,511.00,-2400.63,Race
+E18,1647.23,521.04,-2244.46,RockCircle
 E19,1537.85,505.38,-2091.50,Balloon,High up
-E20,2019.41,557.72,-2172.89,BoulderGolf,Can go after bomb
+E20,2019.41,557.72,-2172.89,BoulderGolf
 E21,2170.73,547.03,-2109.55,BlockPuzzle
 E22,2355.87,524.65,-2067.37,LiftRock,On stone above ring
 E23,2663.89,564.49,-2066.87,LiftRockRubble
-E24,1412.02,408.74,-1759.80,BoulderGolf,WB away after
-E25,1544.33,394.20,-1837.21,Race,Glide and run
-E26,1687.55,427.39,-1717.08,BoulderGolf,Bomb down
+E24,1412.02,408.74,-1759.80,BoulderGolf
+E25,1544.33,394.20,-1837.21,Race
+E26,1687.55,427.39,-1717.08,BoulderGolf
 E27,1950.85,457.49,-1832.65,LiftRockRubble
-E28,2273.79,431.76,-1823.22,Balloon,Aim Above
+E28,2273.79,431.76,-1823.22,Balloon
 E29,2424.33,253.68,-1738.50,Basketball
 E30,2703.71,225.52,-1749.27,BlockPuzzle
-E31,1426.89,465.03,-1544.06,RockCircle,2 rocks
+E31,1426.89,465.03,-1544.06,RockCircle
 E32,2266.55,347.37,-1565.48,LiftRockRubble
-E33,2407.27,328.66,-1613.59,Race,.dir(N>) Turn
+E33,2407.27,328.66,-1613.59,Race
 E34,2751.06,293.76,-1675.90,RockCircle
 E35,1377.20,322.40,-1261.17,RockCircle
-E36,1940.14,226.01,-1217.73,LilyPads,No Drown
+E36,1940.14,226.01,-1217.73,LilyPads
 E37,2179.55,226.34,-1282.03,RockCircle
 E38,2478.57,313.41,-1391.59,BlockPuzzle
-E39,2752.29,233.72,-1366.33,Basketball,GG throw
+E39,2752.29,233.72,-1366.33,Basketball
 E40,2504.47,312.20,-1304.28,LiftRockRubble
-E41,2408.19,262.34,-1229.95,Balloon,Shoot from E42
-E42,2441.13,257.40,-1241.72,LiftRock,Ledge below stone thing
+E41,2408.19,262.34,-1229.95,Balloon
+E42,2441.13,257.40,-1241.72,LiftRock
 E43,2315.02,293.52,-1133.25,LiftRockRubble
-E44,2655.78,261.74,-971.17,LiftRock,Left set of trees
-E45,2275.00,134.98,-720.14,Race,ordinal DEFUSE
+E44,2655.78,261.74,-971.17,LiftRock
+E45,2275.00,134.98,-720.14,Race
 F01,1381.90,288.30,2277.44,AcornTree
-F02,1188.64,323.43,2476.70,Race,.dir(<S) Turn
+F02,1188.64,323.43,2476.70,Race
 F03,1305.28,191.34,2434.05,Balloon
-F04,1323.72,194.40,2453.45,RockCircle,Use tree
+F04,1323.72,194.40,2453.45,RockCircle
 F05,1462.67,336.79,2370.84,Balloon
-F06,2181.72,414.98,2534.69,LiftRock,Peak
+F06,2181.72,414.98,2534.69,LiftRock
 F07,2403.83,256.60,2511.22,LightChase
 F08,1966.62,365.96,2634.47,LiftRockTree
-F09,2099.72,363.66,2625.57,Basketball,2 Stasis hits
+F09,2099.72,363.66,2625.57,Basketball
 F10,1373.00,220.29,2749.04,FlowerChase,In cave
 F11,1936.52,492.98,2778.54,LiftRock,Peak
 F12,2103.91,422.50,2726.09,FlowerChase
 F13,2284.27,287.53,2659.97,LiftRock,Under tree
-F14,2874.91,299.73,2683.36,LilyPads,No Drown
+F14,2874.91,299.73,2683.36,LilyPads
 F15,1325.56,296.66,3008.67,LightChase
 F16,1562.56,298.62,2898.31,Race
-F17,1773.84,346.68,2930.86,Well,(Mag boulder in stone)
+F17,1773.84,346.68,2930.86,Well
 F18,3084.93,239.77,2884.64,LiftRockRubble,In cave
 F19,1785.53,344.36,3011.07,Race,Swim up
-F20,1943.74,348.58,3009.42,MatchTree,Closest
+F20,1943.74,348.58,3009.42,MatchTree
 F21,2294.48,287.50,3028.17,OfferApple
-F22,2951.34,246.57,3005.96,FlowerChase,Round trip
+F22,2951.34,246.57,3005.96,FlowerChase
 F23,1012.06,127.12,3258.18,FlowerChase
-F24,1055.11,167.13,3254.77,Balloon,Shoot from bridge
+F24,1055.11,167.13,3254.77,Balloon
 F25,1406.71,255.48,3198.75,OfferDurian
 F26,1660.15,252.65,3163.64,BlockPuzzle,Middle of waterfall
 F27,1799.42,224.83,3157.65,LiftRock,Ledge
 F28,1803.73,202.60,3221.99,FlowerChase
-F29,2032.28,292.14,3164.34,BlockPuzzle,Piece in lake
-F30,2171.21,198.86,3276.90,MatchTree,West tree
+F29,2032.28,292.14,3164.34,BlockPuzzle,Cube in lake
+F30,2171.21,198.86,3276.90,MatchTree
 F31,2636.23,191.58,3197.79,LiftRockLeaves
 F32,3175.44,309.28,3204.02,LightChase
 F33,3639.77,326.91,3258.22,LiftRock,On ledge
-F34,1492.11,188.12,3370.48,Balloon,3
+F34,1492.11,188.12,3370.48,Balloon
 F35,1857.43,176.84,3351.67,LuminousStone,Eye of statue
-F36,2968.71,122.93,3380.18,RockCircle,Stasis tree
-F37,3289.57,175.80,3338.79,LilyPads,No Drown
+F36,2968.71,122.93,3380.18,RockCircle
+F37,3289.57,175.80,3338.79,LilyPads
 F38,1217.38,135.04,3524.10,LiftRock
 F39,1378.09,256.94,3503.56,OfferDurian
-F40,1449.47,222.69,3531.36,LiftRock,middle of mud
+F40,1449.47,222.69,3531.36,LiftRock,Middle of mud
 F41,1552.48,182.81,3529.24,Beard
 F42,1733.16,168.05,3450.58,Balloon,Middle of bridge
 F43,2139.98,200.28,3531.93,RockCircle
-F44,2836.96,126.87,3452.76,OfferApple,Bomb top of palm tree
+F44,2836.96,126.87,3452.76,OfferApple
 F45,2939.43,122.43,3427.08,FlowerChase,Top of house
 F46,1840.68,135.02,3595.82,BlockPuzzle
 F47,2559.24,344.00,3602.71,LiftRock,Peak
-F48,1757.80,253.70,3685.97,OfferBanana,banana next to it
+F48,1757.80,253.70,3685.97,OfferBanana
 F49,2856.58,113.69,3651.77,RockCircle
-F50,3024.40,107.61,3654.22,FlowerChase,Turn around after beach
+F50,3024.40,107.61,3654.22,FlowerChase
 F51,3367.10,109.90,3653.53,LilyPads
 F52,3796.61,106.29,3618.89,LiftRock
 F53,1374.62,107.24,3751.46,RockCircle
 F54,1513.74,136.27,3725.03,LiftRock,Ledge beach level
 F55,1821.03,272.02,3742.02,LiftRock,Upper ledge
 F56,1625.49,143.74,3891.73,Balloon,Under cliff
-F57,2508.15,157.62,3825.90,RockCircle,Heart
+F57,2508.15,157.62,3825.90,RockCircle
 F58,3170.41,109.88,3824.31,LilyPads,Close to beach rocks
-G01,-4409.10,618.92,331.34,BoulderGolf,Bomb down Stasis hit in
-G02,-4183.67,491.75,291.06,Race,Run
+G01,-4409.10,618.92,331.34,BoulderGolf
+G02,-4183.67,491.75,291.06,Race
 G03,-4066.78,569.14,437.84,RockCircle
 G04,-4355.33,716.59,709.87,BlockPuzzle
-G05,-4325.40,768.44,698.29,Race,.dir(S>)
+G05,-4325.40,768.44,698.29,Race
 G06,-3673.78,550.79,698.30,LiftRock,On wood platform
-G07,-4690.48,704.14,842.36,IceBlock,2 Fire Arrows
+G07,-4690.48,704.14,842.36,IceBlock
 G08,-4340.95,767.38,782.13,FlowerChase
 G09,-3688.84,740.47,798.72,RockCircle
 G10,-3069.67,452.02,910.74,RockCircle
-G11,-4210.02,609.72,1133.50,Race,.dir<E
+G11,-4210.02,609.72,1133.50,Race
 G12,-3224.51,570.76,1022.45,BlockPuzzle
 G13,-2867.81,518.54,1124.92,Confetti,Top of tree
 G14,-2454.27,337.82,1157.30,Balloon
 G15,-4552.23,623.39,1353.15,LiftRock
 G16,-4112.89,560.66,1377.53,LightChase
 G17,-3065.60,604.49,1287.26,IceBlock
-G18,-2850.0,678.32,1229.0,IceBlock,Far one
+G18,-2850.0,678.32,1229.0,IceBlock
 G19,-2521.76,457.05,1318.58,RockCircle
 G20,-4527.83,571.97,1423.32,RockCircle
 G21,-4180.76,440.36,1482.39,BlockPuzzle
 G22,-3129.01,614.01,1467.15,RockCircle
-G23,-2646.00,688.32,1535.13,LiftRock,Peak far
+G23,-2646.00,688.32,1535.13,LiftRock
 G24,-2081.09,353.63,1477.02,RockCircle
-G25,-4075.58,298.89,1595.13,OfferBanana,Pick up 3
-G26,-3715.85,570.37,1558.07,SnowballGolf,Carry halfway
+G25,-4075.58,298.89,1595.13,OfferBanana
+G26,-3715.85,570.37,1558.07,SnowballGolf
 G27,-2817.46,578.22,1652.72,RockCircle,Platform on cliff
 G28,-2464.74,417.71,1713.47,BlockPuzzle
 G29,-1799.60,114.89,1625.90,BlockPuzzle
 G30,-4136.39,401.44,1717.95,RockCircle
-G31,-3845.23,412.26,1897.05,Balloon,Wait in BT
-G32,-2429.13,203.48,1921.33,Race,Run
+G31,-3845.23,412.26,1897.05,Balloon
+G32,-2429.13,203.48,1921.33,Race
 G33,-4170.68,193.18,1989.38,RockCircle
-G34,-3071.38,197.78,2044.73,BlockPuzzle,Bottom right
-G35,-2697.26,270.84,2105.06,Race,SQ DEFUSE
+G34,-3071.38,197.78,2044.73,BlockPuzzle
+G35,-2697.26,270.84,2105.06,Race
 G36,-1721.22,143.19,2237.78,Well
 H01,-4397.60,332.44,-3773.91,BlockPuzzle
-H02,-4029.33,464.85,-3760.17,IceBlock,Left one
+H02,-4029.33,464.85,-3760.17,IceBlock
 H03,-3960.37,350.67,-3723.25,FlowerChase
-H04,-3757.12,375.46,-3848.08,RockCircle,Rock behind camp
-H05,-1970.93,420.71,-3792.56,Balloon,Bomb Arrow (Turn around)
+H04,-3757.12,375.46,-3848.08,RockCircle
+H05,-1970.93,420.71,-3792.56,Balloon
 H06,-1375.17,361.92,-3640.94,RockCircle
-H07,-4167.16,516.82,-3615.93,Race,Surf down FAST
-H08,-3999.21,632.96,-3620.06,Balloon,SBR
+H07,-4167.16,516.82,-3615.93,Race
+H08,-3999.21,632.96,-3620.06,Balloon
 H09,-3496.12,474.21,-3580.67,LiftRockLeaves
-H10,-3610.64,561.92,-3491.99,AcornLog,Farthest set of trees
+H10,-3610.64,561.92,-3491.99,AcornLog
 H11,-3414.79,542.02,-3509.61,Confetti,Top of bare tree
 H12,-2842.69,333.93,-3493.48,RockCircle
-H13,-2290.10,564.25,-3407.59,IceBlock,3 FA
+H13,-2290.10,564.25,-3407.59,IceBlock
 H14,-1535.29,346.88,-3475.81,AcornLog
 H15,-1095.98,413.97,-3399.87,BlockPuzzle
-H16,-872.89,335.50,-3316.10,Balloon,Bomb tree
-H17,-4155.93,350.44,-3404.12,RockCircle,Snowy Platform
+H16,-872.89,335.50,-3316.10,Balloon
+H17,-4155.93,350.44,-3404.12,RockCircle,Snowy platform
 H18,-3843.15,435.38,-3348.18,Confetti,Forest with 5 trees
-H19,-3574.57,494.23,-3272.38,Balloon,First Forest on right
+H19,-3574.57,494.23,-3272.38,Balloon
 H20,-2946.50,686.98,-3146.69,Confetti,Top of house
 H21,-2602.17,508.35,-3238.93,Confetti,Top of tree
-H22,-1110.79,438.06,-3043.85,BoulderGolf,WB away after
+H22,-1110.79,438.06,-3043.85,BoulderGolf
 H23,-4424.15,497.16,-3215.94,LiftRock,Peak far
 H24,-4230.89,284.85,-3134.81,FlowerChase,Below high forest
 H25,-3793.73,353.06,-3032.96,LiftRock,In corner
 H26,-3734.78,446.58,-2964.39,LiftRock
 H27,-3350.52,621.95,-2994.89,Balloon
 H28,-2783.55,838.53,-2895.52,LiftRock
-H29,-2487.65,514.33,-3021.60,IceBlock,3-4 FA
+H29,-2487.65,514.33,-3021.60,IceBlock
 H30,-2250.21,446.80,-3092.18,AcornFlying
-H31,-2210.05,498.64,-2908.54,IceBlock,2 FA
+H31,-2210.05,498.64,-2908.54,IceBlock
 H32,-4402.55,415.03,-2866.69,LightChase,On flat hill
 H33,-3115.96,496.35,-2806.23,IceBlock
 H34,-3061.22,535.21,-2813.68,IceBlock
-H35,-2830.55,669.61,-2828.34,LiftRock,Clear Ragdoll
-H36,-2467.77,620.80,-2765.22,RockCircle,2
+H35,-2830.55,669.61,-2828.34,LiftRock
+H36,-2467.77,620.80,-2765.22,RockCircle
 H37,-1781.00,347.36,-2745.01,LightChase
 H38,-1349.37,241.70,-2734.51,LiftRockRubble
-H39,-4192.80,288.37,-2678.94,FlowerChase,A bit over updraft
+H39,-4192.80,288.37,-2678.94,FlowerChase
 H40,-4330.86,441.88,-2600.16,LiftRock,Top of hill
 H41,-4148.75,216.39,-2616.47,RockCircle
-H42,-4071.81,131.41,-2545.94,LiftRockRubble,Drop down 2 levels
+H42,-4071.81,131.41,-2545.94,LiftRockRubble
 H43,-3277.42,585.32,-2618.86,AcornLog
 H44,-2984.89,559.20,-2693.52,Balloon,In cave
 H45,-2736.11,456.88,-2582.83,IceBlock
 H46,-3041.11,430.43,-2520.18,IceBlock
-H47,-2900.08,498.64,-2508.78,Balloon,End of river BA
+H47,-2900.08,498.64,-2508.78,Balloon,End of river
 H48,-2936.53,471.20,-2412.46,LiftRock,On ledge
 H49,-2883.83,521.33,-2398.01,Race
 H50,-2836.29,501.87,-2423.83,Balloon,Middle of river
@@ -404,41 +404,41 @@ H58,-1764.0,343.69,-2350.70,LiftRockLeaves
 H59,-1414.64,228.58,-2398.59,BoulderGolf
 H60,-4507.23,226.34,-2146.10,Balloon
 H61,-2382.54,498.73,-2132.67,LiftRock,Peak
-H62,-1682.21,353.47,-2184.83,Balloon,1 below 2 behind
+H62,-1682.21,353.47,-2184.83,Balloon
 H63,-1675.99,96.53,-2139.30,LiftRock,Ledge
 H64,-2636.62,444.70,-2048.35,LiftRock,Behind shrine
 H65,-2791.12,397.69,-1945.59,Confetti,Top of tree (island)
-H66,-2972.81,377.29,-1878.10,LilyPads,No Drown
+H66,-2972.81,377.29,-1878.10,LilyPads
 H67,-2358.59,385.00,-1872.80,Well
 H68,-2012.59,127.18,-1921.69,LiftRock
-H69,-2523.39,364.82,-1736.94,AcornLog,Midair
+H69,-2523.39,364.82,-1736.94,AcornLog
 H70,-2338.22,369.24,-1726.70,FlowerChase
 H71,-2207.48,253.30,-1767.46,LiftRockRubble
 H72,-2836.95,348.83,-1594.78,Confetti,Top of windmill
-H73,-2826.25,193.14,-1580.07,Race,.dir(<N)
-K01,206.76,233.04,-3559.00,LiftRock,On peak FAR
+H73,-2826.25,193.14,-1580.07,Race
+K01,206.76,233.04,-3559.00,LiftRock
 K02,603.39,249.91,-3633.77,BlockPuzzle
 K03,1143.40,209.96,-3742.77,RockCircle
-K04,863.91,316.28,-3358.52,Balloon,5 around tree
-K05,-486.71,231.99,-3142.91,Balloon,Backflip BT
-K06,-40.78,306.50,-2985.74,AcornLog,Shoot from midair
-K07,237.43,304.06,-2943.38,Balloon,No BT
-K08,685.12,431.88,-2758.45,Balloon,Instant Shoot
+K04,863.91,316.28,-3358.52,Balloon
+K05,-486.71,231.99,-3142.91,Balloon
+K06,-40.78,306.50,-2985.74,AcornLog
+K07,237.43,304.06,-2943.38,Balloon
+K08,685.12,431.88,-2758.45,Balloon
 K09,-1045.91,54.66,-2707.63,LiftRock,Behind statue
-K10,-1047.62,139.68,-2620.56,BlockPuzzle,Cube behind left group
-K11,-567.78,489.60,-2599.20,LiftRock,Peak FAR
+K10,-1047.62,139.68,-2620.56,BlockPuzzle
+K11,-567.78,489.60,-2599.20,LiftRock
 K12,-1258.63,138.61,-2360.09,LiftRockRubble
 K13,-1403.11,101.02,-2312.28,LiftRockRubble
 K14,-1410.55,1.01,-2224.80,LiftRockDoor
 K15,-1586.48,68.14,-2133.00,LiftRock,On pillar
 K16,-1019.51,222.85,-2077.29,AcornLog
-K17,-1309.76,209.07,-1941.56,JumpFence,Summon Horse
+K17,-1309.76,209.07,-1941.56,JumpFence
 K18,-1062.99,226.91,-1934.10,Confetti,Top of broken hut
 K19,-816.67,224.46,-1926.15,AcornLog
 K20,-1884.49,23.98,-1813.18,LiftRock,End of ledge
 K21,-1805.35,31.56,-1842.52,LiftRockRubble
 K22,-2036.94,48.70,-1622.94,LiftRockRubble,In corner
-K23,-1436.28,231.00,-1668.66,AcornLog,Shoot midair
+K23,-1436.28,231.00,-1668.66,AcornLog
 K24,-1227.23,255.95,-1578.17,LightChase
 K25,-1094.13,210.87,-1731.89,RockCircle
 K26,-911.80,219.25,-1612.79,Balloon,Pinwheel
@@ -449,7 +449,7 @@ K30,-130.54,168.77,-1379.27,LiftRock,Ledge
 K31,1008.13,270.26,-1564.01,LiftRock,Top of scaffolding
 K32,868.01,209.81,-1362.16,AcornTree
 K33,1197.52,126.97,-1152.62,BlockPuzzle
-K34,1282.64,129.64,-1123.44,LilyPads,No Drown
+K34,1282.64,129.64,-1123.44,LilyPads
 K35,1694.87,141.95,-862.08,BlockPuzzle
 L01,323.49,118.23,1927.42,Well
 L02,354.38,114.56,1997.54,LiftRock,In big tree stump
@@ -457,16 +457,16 @@ L03,34.27,115.55,2102.72,BlockPuzzle
 L04,214.57,170.07,2070.05,TreeStump
 L05,400.86,142.06,2150.86,FlowerChase
 L06,474.95,115.26,2149.12,LightChase
-L07,908.28,247.17,2193.52,BoulderGolf,5 Stasis hits aim straight
-L08,-609.80,95.24,2390.65,Race,SQ DEFUSE
+L07,908.28,247.17,2193.52,BoulderGolf
+L08,-609.80,95.24,2390.65,Race
 L09,-68.02,91.39,2332.61,Basketball
-L10,66.22,94.00,2310.64,LilyPads,No Drown
+L10,66.22,94.00,2310.64,LilyPads
 L11,284.29,146.79,2253.37,TreeStump
-L12,625.16,164.76,2305.90,BlockPuzzle,Piece on tree
+L12,625.16,164.76,2305.90,BlockPuzzle
 L13,755.69,194.09,2347.60,LiftRockRubble
-L14,-74.38,90.54,2412.87,LiftRockSlab,Stasis a lot
+L14,-74.38,90.54,2412.87,LiftRockSlab
 L15,-66.24,124.00,2440.65,Balloon,In pillar
-L16,280.42,97.65,2405.01,BoulderGolf,Bomb down stasis
+L16,280.42,97.65,2405.01,BoulderGolf
 L17,604.93,177.15,2408.78,LightChase
 L18,609.28,177.23,2409.82,LightChase
 L19,889.61,180.86,2395.30,LiftRockTree,Top of big tree
@@ -474,7 +474,7 @@ L20,833.75,145.33,2434.57,BlockPuzzle
 L21,-1379.58,215.09,2742.73,BlockPuzzle
 L22,-1214.31,193.47,2701.55,AcornHanging,From tree
 L23,-1011.91,330.57,2638.46,Confetti,Top of tree
-L24,-601.95,90.30,2656.11,LiftRock,3rd hole
+L24,-601.95,90.30,2656.11,LiftRock
 L25,-398.39,103.86,2559.23,Confetti,Top of tree
 L26,-54.77,128.94,2492.43,TreeBranch
 L27,-38.98,152.95,2513.64,Confetti,Top of fountain
@@ -484,15 +484,15 @@ L30,-12.47,119.77,2586.32,FlowerChase
 L31,-3.03,90.67,2614.66,LiftRock
 L32,200.87,92.34,2603.86,MetalBoxCircle
 L33,370.41,92.51,2567.04,Balloon
-L34,790.63,159.60,2565.13,BoulderCircle,Stasis Jump ATK down
+L34,790.63,159.60,2565.13,BoulderCircle
 L35,584.43,217.51,2678.33,MatchTree
-L36,-1066.79,208.43,2910.01,Balloon,Bomb in tree
+L36,-1066.79,208.43,2910.01,Balloon
 L37,-925.24,237.01,2936.44,AcornLog
-L38,-468.64,98.70,2908.23,BlockPuzzle,2nd hole
+L38,-468.64,98.70,2908.23,BlockPuzzle
 L39,163.27,90.20,2783.29,LiftRock
 L40,340.62,94.23,2830.62,AcornTree
 L41,-1256.74,323.02,3134.15,LiftRockRubble
-L42,224.17,135.20,2868.40,BoulderGolf,Bomb in
+L42,224.17,135.20,2868.40,BoulderGolf
 L43,169.73,118.72,2903.41,LightChase
 L44,418.20,128.01,2873.40,BoulderGolf
 L45,610.34,206.40,2869.85,LiftRock
@@ -501,36 +501,36 @@ L47,-387.59,152.98,3151.55,Race
 L48,-150.92,143.38,3067.30,LiftRock
 L49,-95.25,144.64,3128.95,RockCircle
 L50,-26.89,107.81,3042.68,BlockPuzzle
-L51,153.94,143.86,2981.71,BoulderGolf,2 Stasis + bomb in
+L51,153.94,143.86,2981.71,BoulderGolf
 L52,406.11,139.90,3051.13,LiftRock,On pillar
-L53,581.24,123.03,3007.60,TreeStump,Left next to shrine
-L54,704.03,120.0,2957.83,LilyPads,No Drown
+L53,581.24,123.03,3007.60,TreeStump
+L54,704.03,120.0,2957.83,LilyPads
 L55,695.52,119.43,3071.40,FlowerChase
-L56,824.94,120.73,3005.30,BoulderCircle,Stasis + Magnesis
+L56,824.94,120.73,3005.30,BoulderCircle
 L57,806.07,124.54,3112.85,LightChase
 L58,1196.09,132.03,3055.43,LightChase
-L59,56.69,109.89,3150.02,LilyPads,No Drown
+L59,56.69,109.89,3150.02,LilyPads
 L60,69.03,127.14,3221.87,LiftRockRubble
-L61,742.89,134.01,3243.07,LiftRockSlab,Stasis 1 hit
-L62,-923.50,214.58,3436.38,LiftRockRubble,Middle of 3
+L61,742.89,134.01,3243.07,LiftRockSlab
+L62,-923.50,214.58,3436.38,LiftRockRubble
 L63,-420.75,141.37,3368.48,OfferApple
 L64,-227.28,176.72,3342.73,FlowerChase
 L65,271.71,222.37,3289.58,Race,Ordinal
-L66,699.92,133.67,3276.86,Basketball,Cryo block
-L67,-1176.85,344.99,3578.05,Balloon,SBR
+L66,699.92,133.67,3276.86,Basketball
+L67,-1176.85,344.99,3578.05,Balloon
 L68,-1125.95,315.84,3624.42,LightChase
 L69,-878.72,245.87,3567.74,BlockPuzzle
-L70,216.32,199.14,3488.01,AcornFlying,Bomb Arrow if can
+L70,216.32,199.14,3488.01,AcornFlying
 L71,279.02,184.63,3503.79,RockCircle
-L72,963.30,173.48,3371.10,Race,.dir(N>) Turn
+L72,963.30,173.48,3371.10,Race
 L73,266.10,276.46,3668.95,Balloon,On peak
-L74,367.09,176.93,3642.11,BoulderGolf,Drop down Stasis
-L75,645.72,152.30,3615.12,LilyPads,No Drown
-L76,522.46,166.30,3680.95,BoulderGolf,Stasis 2 + BTMA
+L74,367.09,176.93,3642.11,BoulderGolf
+L75,645.72,152.30,3615.12,LilyPads
+L76,522.46,166.30,3680.95,BoulderGolf
 L77,639.39,219.09,3710.83,RockCircle
 L78,891.16,284.36,3694.82,LiftRock,Peak
 L79,1074.54,182.09,3620.94,RockCircle
-L80,-657.76,187.62,3851.83,Race,cardinal
+L80,-657.76,187.62,3851.83,Race
 L81,-354.83,182.59,3898.78,LiftRock
 L82,-266.35,125.15,3888.15,Confetti,Top of palm tree
 L83,-248.98,130.31,3828.44,LiftRockRubble
@@ -539,98 +539,98 @@ L85,-135.83,105.97,3802.00,RockCircle
 L86,13.95,106.59,3790.42,LiftRockBoulder
 L87,97.36,145.46,3821.54,LiftRock,Top of rock
 L88,265.62,111.81,3837.00,LightChase
-L89,286.83,109.90,3899.42,LilyPads,SEAWEED
+L89,286.83,109.90,3899.42,LilyPads
 L90,416.75,106.41,3848.92,BlockPuzzle
 L91,517.56,193.85,3765.02,RockCircle
 L92,909.62,183.59,3837.29,BlockPuzzle
 N01,1980.92,174.27,451.91,LiftRockTree
 N02,2378.29,231.61,373.14,LiftRockTree
-N03,2635.69,269.52,370.99,LiftRockTree,behind shrine
-N04,2473.88,231.46,461.69,AcornFlying,Bullet time
+N03,2635.69,269.52,370.99,LiftRockTree
+N04,2473.88,231.46,461.69,AcornFlying
 N05,2684.85,218.51,562.78,LightChase,Small pond
 N06,2891.03,234.15,517.87,Confetti,Top of tall tree
-N07,2132.42,321.11,678.84,MatchTree,Bomb left
+N07,2132.42,321.11,678.84,MatchTree
 N08,2149.35,262.51,790.00,BlockPuzzle
 N09,2239.66,337.97,726.35,OfferApple
 N10,2288.52,250.79,699.62,FlowerChase
-N11,2409.54,269.60,849.31,BoulderGolf,WB away after
+N11,2409.54,269.60,849.31,BoulderGolf
 N12,3951.86,106.31,695.88,RockCircle
-N13,2728.91,342.09,904.32,BoulderCircle,2 separate Stasis hits
+N13,2728.91,342.09,904.32,BoulderCircle
 N14,3383.03,118.78,982.82,RockCircle
 N15,2636.16,205.28,1108.99,LilyPads
 N16,2705.43,203.10,1164.94,LiftRock
-N17,3432.94,342.95,1150.31,Race,.dir(S) Round First DEFUSE
-N18,3741.71,542.51,1156.12,IceBlock,3 Fire Arrows
+N17,3432.94,342.95,1150.31,Race
+N18,3741.71,542.51,1156.12,IceBlock
 N19,4087.93,423.30,1142.37,RockCircle
 N20,2526.61,334.82,1257.57,RockCircle
-N21,2925.46,478.75,1401.57,LiftRock,Peak (FAR)
+N21,2925.46,478.75,1401.57,LiftRock
 N22,3277.77,346.34,1436.00,BlockPuzzle
 N23,3537.01,313.54,1376.11,LightChase,In forest
-N24,3797.93,577.85,1269.19,IceBlock,Behind peak 4 Fire Arrows
-N25,4438.90,141.72,1432.91,BoulderGolf,Bomb + Stasis
-N26,2276.03,162.25,1501.62,BoulderGolf,WB away after
+N24,3797.93,577.85,1269.19,IceBlock
+N25,4438.90,141.72,1432.91,BoulderGolf
+N26,2276.03,162.25,1501.62,BoulderGolf
 N27,2279.31,182.42,1608.34,LiftRockRubble
 N28,2511.43,120.03,1571.52,OfferApple
-N29,3171.94,293.84,1490.93,LilyPads,No Drown
-N30,3229.03,302.83,1545.24,MatchTree,Farthest tree from lake
-N31,3896.64,416.66,1556.54,IceBlock,3 Fire Arrows
-N32,4282.68,289.03,1655.66,Race,SQ
+N29,3171.94,293.84,1490.93,LilyPads
+N30,3229.03,302.83,1545.24,MatchTree
+N31,3896.64,416.66,1556.54,IceBlock
+N32,4282.68,289.03,1655.66,Race
 N33,2320.66,119.27,1726.36,LiftRockDoor
 N34,2330.77,133.96,1828.01,AcornFlying
 N35,2495.85,205.50,1804.20,BlockPuzzle
 N36,2884.09,160.92,1765.02,AcornTree
-N37,3178.81,177.00,1607.30,LilyPads,C ryo block DIVE
+N37,3178.81,177.00,1607.30,LilyPads
 N38,3166.32,193.83,1828.89,Balloon
-N39,3525.98,454.04,1710.62,Race,.dir(W) Round First
+N39,3525.98,454.04,1710.62,Race
 N40,4615.14,106.21,1915.47,LiftRockSlab
-N41,3029.03,114.80,2017.67,LilyPads,Cryo block
+N41,3029.03,114.80,2017.67,LilyPads
 N42,3475.63,278.69,1916.26,LiftRockTree,Next to blue flame
-N43,3709.19,301.45,1943.08,LiftRockTree,middle of lake
+N43,3709.19,301.45,1943.08,LiftRockTree,Middle of lake
 N44,4274.36,430.79,1981.02,FlowerChase
 N45,2836.32,126.63,2120.50,Balloon
 N46,2863.86,140.26,2182.90,LiftRockDoor
 N47,3783.72,390.72,2125.18,Confetti,Top of lab
-N48,3901.08,235.80,2096.72,LilyPads,Drown
-N49,2714.13,225.53,2345.55,AcornTree,Shoot from N50
-N50,2811.31,239.61,2391.92,MatchTree,Get Wood
+N48,3901.08,235.80,2096.72,LilyPads
+N49,2714.13,225.53,2345.55,AcornTree
+N50,2811.31,239.61,2391.92,MatchTree
 N51,2991.39,118.10,2272.14,LiftRock,Side of lake
 N52,3144.46,163.40,2229.85,AcornTree
 N53,3347.61,209.94,2249.25,LiftRock
 N54,4211.83,106.38,2270.37,OfferPalmFruit,In cave
-N55,4518.49,219.77,2316.51,Balloon,Turn Right
-N56,4541.93,109.80,2405.63,LilyPads,Cryo block wb
+N55,4518.49,219.77,2316.51,Balloon
+N56,4541.93,109.80,2405.63,LilyPads
 N57,4662.71,169.59,2376.25,FlowerChase
 N58,3148.71,277.19,2402.78,BlockPuzzle
-N59,3420.94,340.35,2390.28,FlowerChase,6 before going right
-N60,3687.95,107.32,2413.49,Basketball,Cryo GG Throw
+N59,3420.94,340.35,2390.28,FlowerChase
+N60,3687.95,107.32,2413.49,Basketball
 N61,3516.11,160.20,2628.38,RockCircle
-N62,4110.97,111.15,2588.16,FlowerChase,Start on beach
+N62,4110.97,111.15,2588.16,FlowerChase,Starts on beach
 N63,4536.52,106.44,2520.27,RockCircle
 N64,3229.81,256.54,2848.44,MatchTree
 N65,3441.93,216.08,3121.87,RockCircle
 N66,4083.59,109.36,2973.26,Race
-P01,-822.63,171.23,1546.92,LiftRock,Under rocks
+P01,-822.63,171.23,1546.92,LiftRock
 P02,-769.88,175.22,1574.22,TreeStump
 P03,-1334.80,232.67,1675.89,BlockPuzzle
 P04,-965.48,187.20,1625.69,FlowerChase,Middle of log
 P05,-853.23,181.42,1671.21,LiftRockLeaves
 P06,-953.06,201.55,1721.48,LiftRock,Top of hill
 P07,-1503.42,297.22,1920.17,IceBlock
-P08,-1382.26,249.27,1858.03,Confetti,Cryo log
-P09,-1132.60,238.22,1917.72,Confetti,Inside SOR
-P10,-887.32,208.14,1891.40,LilyPads,No Drown
-P11,-809.22,297.75,1966.90,Confetti,Top of ToT
+P08,-1382.26,249.27,1858.03,Confetti
+P09,-1132.60,238.22,1917.72,Confetti,Inside SoR
+P10,-887.32,208.14,1891.40,LilyPads
+P11,-809.22,297.75,1966.90,Confetti,Spire of Temple
 P12,-423.02,169.40,1993.36,LiftRockDoor
 P13,-423.35,125.26,2022.45,LiftRockDoor
 P14,-1443.11,284.25,2105.63,BlockPuzzle
 P15,-1363.46,335.70,2215.19,RockCircle
-P16,-1204.35,329.34,2322.77,LiftRockSlab,1 Stasis
+P16,-1204.35,329.34,2322.77,LiftRockSlab
 P17,-1171.61,342.50,2317.22,LiftRock
 P18,-792.03,201.39,2257.22,Confetti,Top of hut
 R01,-2210.59,152.82,-1621.40,BlockPuzzle
 R02,-2217.82,321.18,-1565.02,LiftRock
 R03,-2083.96,293.08,-1558.72,LiftRockRubble
-R04,-2516.12,61.96,-1436.30,RockCircle,In Canyon
+R04,-2516.12,61.96,-1436.30,RockCircle,In canyon
 R05,-2636.28,300.54,-1246.99,AcornTree
 R06,-2022.65,390.93,-1300.63,Confetti,Top of bare tree
 R07,-1077.38,238.53,-1278.70,LiftRockTree
@@ -641,36 +641,36 @@ R11,-1017.85,116.95,-1066.07,Basketball
 R12,-3109.25,34.17,-909.26,Confetti,Top of flagpole
 R13,-2669.55,375.56,-864.39,LiftRock,Top of waterfall
 R14,-2316.80,206.68,-806.45,LightChase
-R15,-2060.66,259.49,-775.78,RockCircle,3 on mushroom tree
+R15,-2060.66,259.49,-775.78,RockCircle
 R16,-1142.41,182.62,-761.94,BlockPuzzle
 R17,-2698.41,414.59,-766.74,LiftRock,Top of mountain
 R18,-1964.67,221.20,-584.16,Race,Run
-R19,-1125.27,157.91,-675.43,BoulderGolf,WB away after
+R19,-1125.27,157.91,-675.43,BoulderGolf
 R20,-3207.78,37.56,-494.89,BlockPuzzle
 R21,-2715.90,269.56,-429.86,LightChase
-R22,-2434.11,319.86,-491.03,Balloon,Aim a bit above
+R22,-2434.11,319.86,-491.03,Balloon
 R23,-2030.12,206.47,-547.60,FlowerChase
-R24,-2008.68,210.31,-514.15,LilyPads,No Drown
-R25,-1631.54,210.43,-515.19,Race,Ordinal Delay
-R26,-1115.55,151.98,-528.58,Race,.dir(W)
+R24,-2008.68,210.31,-514.15,LilyPads
+R25,-1631.54,210.43,-515.19,Race
+R26,-1115.55,151.98,-528.58,Race
 R27,-1092.08,129.02,-497.51,AcornHanging,From bridge
 R28,-3327.44,3.92,-336.92,LiftRockSlab
 R29,-3207.55,5.91,-333.98,LiftRock,In between rocks
-R30,-2547.83,299.94,-306.30,Race,SQ
-R31,-2370.10,307.04,-345.30,Balloon,Aim direct
+R30,-2547.83,299.94,-306.30,Race
+R31,-2370.10,307.04,-345.30,Balloon
 R32,-4252.40,171.93,-84.01,Balloon
 R33,-4026.70,145.21,-232.40,RockCircle
-R34,-3861.73,101.01,-147.15,AcornHanging,below tower
-R35,-3828.83,160.15,-118.42,Race,SQ DEFUSE
+R34,-3861.73,101.01,-147.15,AcornHanging,Below tower
+R35,-3828.83,160.15,-118.42,Race
 R36,-3476.20,154.93,-69.05,LiftRock,On ledge
 R37,-2312.60,262.63,24.01,LiftRock,Ledge
-R38,-1877.90,243.70,-32.18,MatchTree,Right tree
+R38,-1877.90,243.70,-32.18,MatchTree
 R39,-1691.98,224.96,-175.52,LightChase,Near 2 rocks
 R40,-1590.03,210.73,-229.13,LiftRockSlab
 R41,-1650.75,224.85,-46.55,FlowerCount
 R42,-1372.53,115.84,-107.98,LiftRock,Riverbank
-R43,-1258.40,159.75,-240.51,Balloon,Aim a bit above
-R44,-1142.67,116.47,-284.33,Basketball,GG rock throw
+R43,-1258.40,159.75,-240.51,Balloon
+R44,-1142.67,116.47,-284.33,Basketball
 R45,-1148.19,149.37,-226.68,FlowerChase,Start at pillar
 R46,-3464.51,172.14,172.49,FlowerCount
 R47,-1992.89,291.31,161.31,Balloon
@@ -692,14 +692,14 @@ R62,-2175.12,407.09,463.35,Race,Cardinal
 R63,-2645.97,300.16,547.92,LiftRockLeaves
 R64,-2483.31,328.14,504.73,LiftRockRubble
 R65,-2483.61,307.72,545.07,FlowerCount
-R66,-2492.70,310.45,589.67,TreeStump,Magnesis 2
+R66,-2492.70,310.45,589.67,TreeStump
 R67,-2542.83,307.78,639.85,Basketball
-R68,-1965.81,255.74,600.94,Balloon,Backflip
-R69,-2053.48,258.46,636.41,AcornLog,Shoot from far
+R68,-1965.81,255.74,600.94,Balloon
+R69,-2053.48,258.46,636.41,AcornLog
 R70,-2200.96,358.41,730.84,LiftRockBoulder
 R71,-2908.73,116.66,796.26,LiftRock
 R72,-2729.92,219.93,761.38,LiftRockLeaves
-R73,-2351.14,263.40,846.17,BoulderGolf,Stasis + shoot
+R73,-2351.14,263.40,846.17,BoulderGolf
 R74,-1551.96,167.38,815.48,LiftRock
 R75,-2393.36,233.04,1047.34,AcornHanging,Bomb from midair
 R76,-2340.70,249.86,1104.57,LiftRockTree
@@ -707,13 +707,13 @@ R77,-2099.38,205.46,1104.72,AcornHanging,From tree
 R78,-1969.74,205.39,1087.83,OfferApple
 R79,-1819.30,248.49,973.59,OfferApple
 R80,-1819.09,206.17,1532.64,LiftRock
-T01,-4019.88,130.80,-2350.35,FlowerChase,Left to rubble
+T01,-4019.88,130.80,-2350.35,FlowerChase
 T02,-3792.61,283.47,-2320.19,Confetti,Top of house
-T03,-2989.56,222.60,-2164.98,LilyPads,No Drown
+T03,-2989.56,222.60,-2164.98,LilyPads
 T04,-3831.34,248.41,-2106.70,Well
 T05,-3418.51,286.38,-2066.81,LiftRock
-T06,-4396.83,183.40,-2049.88,Race,.dir(NE)
-T07,-4330.52,160.93,-2052.85,RockCircle,3
+T06,-4396.83,183.40,-2049.88,Race
+T07,-4330.52,160.93,-2052.85,RockCircle
 T08,-4482.92,266.76,-1970.87,LiftRock
 T09,-4123.61,303.52,-1935.33,OfferPepper
 T10,-3780.53,368.60,-1865.62,OfferApple
@@ -723,9 +723,9 @@ T13,-4034.98,273.22,-1748.40,RockCircle
 T14,-3627.38,453.55,-1804.82,Balloon
 T15,-3562.24,289.50,-1761.34,LiftRock
 T16,-4065.46,316.05,-1678.32,FlowerChase
-T17,-3696.66,211.10,-1684.10,Race,Ordinal Low
+T17,-3696.66,211.10,-1684.10,Race
 T18,-2910.18,382.29,-1639.03,Confetti,Top of tree
-T19,-3151.57,185.5,-1563.28,LilyPads,No Drown
+T19,-3151.57,185.5,-1563.28,LilyPads
 T20,-3444.36,231.21,-1328.68,BlockPuzzle
 T21,-3295.15,250.09,-1362.92,LiftRockRubble
 T22,-3125.19,263.00,-1366.50,LiftRockRubble
@@ -734,32 +734,32 @@ T24,-3714.73,302.72,-1040.96,LiftRock,Behind malice
 T25,-3078.34,207.99,-1120.35,LiftRock,On ledge
 T26,-3971.63,213.63,-920.51,TreeStump
 T27,-4058.83,208.52,-773.85,OfferApple
-T28,-3841.71,218.41,-803.98,BoulderGolf,Run after bomb
+T28,-3841.71,218.41,-803.98,BoulderGolf
 T29,-3803.93,251.28,-772.46,LiftRock
-T30,-3661.36,257.37,-828.80,Race,SQ High
+T30,-3661.36,257.37,-828.80,Race
 T31,-3431.20,278.01,-707.84,OfferApple
 T32,-3966.31,293.92,-624.56,LiftRock,On pillar
-T33,-3441.07,357.36,-664.87,Balloon,Use bomb
-T34,-3212.85,235.00,-574.01,Race,.dir(W)
-T35,-3524.55,373.78,-449.69,LilyPads,No Drown
+T33,-3441.07,357.36,-664.87,Balloon
+T34,-3212.85,235.00,-574.01,Race
+T35,-3524.55,373.78,-449.69,LilyPads
 T36,-4032.73,239.31,-350.42,FlowerCount
-T37,-3675.03,390.49,-393.32,Race,SQ DEFUSE
+T37,-3675.03,390.49,-393.32,Race
 W01,-3847.19,471.28,1467.01,LiftRock
-W02,-4001.07,324.38,1566.55,OfferBanana,Pick up 4
-W03,-4314.10,219.01,1629.40,OfferBanana,No pick up
-W04,-4220.02,257.54,1659.79,OfferBanana,Pick up all
-W05,-4266.57,226.05,1691.53,OfferBanana,Pick up 1
+W02,-4001.07,324.38,1566.55,OfferBanana
+W03,-4314.10,219.01,1629.40,OfferBanana
+W04,-4220.02,257.54,1659.79,OfferBanana
+W05,-4266.57,226.05,1691.53,OfferBanana
 W06,-4353.38,242.21,1838.52,FlowerChase
 W07,-2066.65,228.32,1850.09,BlockPuzzle
 W08,-2417.31,191.19,1923.72,Confetti,In crack
 W09,-4685.21,171.46,1970.38,Confetti,Highest fin on skeleton
-W10,-2550.17,190.00,2038.10,Balloon,Bomb crack
+W10,-2550.17,190.00,2038.10,Balloon
 W11,-2167.78,336.44,2082.04,LiftRockTree
-W12,-2264.51,356.98,2163.37,AcornHanging,Bomb midair
+W12,-2264.51,356.98,2163.37,AcornHanging
 W13,-4710.48,209.71,2171.83,Confetti,Highest fin on skeleton
 W14,-2018.63,188.73,2186.64,LiftRock,End of bridge
 W15,-2815.31,160.71,2247.91,LiftRock,On pillar
-W16,-2259.54,357.45,2224.75,BoulderGolf,2 MS Hits
+W16,-2259.54,357.45,2224.75,BoulderGolf
 W17,-3353.03,156.91,2276.30,BlockPuzzle
 W18,-4607.90,161.60,2338.84,Confetti,Top of skeleton (pinwheel)
 W19,-2853.36,210.49,2320.15,LiftRock
@@ -770,15 +770,15 @@ W23,-2066.65,288.81,2397.04,Race
 W24,-2059.88,306.77,2420.09,LiftRock,On platform
 W25,-4876.90,153.29,2469.67,MatchCactus
 W26,-1809.82,162.51,2459.62,BlockPuzzle
-W27,-1615.96,193.37,2447.32,Balloon,2 Bomb Arrows (No BT)
-W28,-4373.89,165.13,2587.05,Race,On some pillars
-W29,-3751.84,157.35,2531.62,Race,SQ DEFUSE
+W27,-1615.96,193.37,2447.32,Balloon
+W28,-4373.89,165.13,2587.05,Race
+W29,-3751.84,157.35,2531.62,Race
 W30,-2594.75,284.72,2539.86,BlockPuzzle
 W31,-2358.78,476.12,2554.53,LiftRock
 W32,-2305.08,486.25,2561.36,BlockPuzzle
 W33,-2207.69,432.16,2550.62,Balloon,Under bridge
 W34,-1935.34,452.79,2673.50,RockCircle
-W35,-2628.11,168.49,2751.20,Balloon,Between arms. Shoot midair
+W35,-2628.11,168.49,2751.20,Balloon,Between statue arms
 W36,-4224.86,154.65,2738.07,MatchCactus
 W37,-3107.27,135.38,2881.24,FlowerChase,On skeleton
 W38,-2298.69,352.56,2850.02,LiftRock,On pillar
@@ -801,9 +801,9 @@ W54,-1526.97,397.51,3405.89,LiftRock
 W55,-4307.61,132.16,3459.74,LiftRock,On a rock
 W56,-3799.64,128.15,3428.88,LiftRock
 W57,-3728.54,166.48,3610.08,Balloon,On tree in oasis
-W58,-1996.60,301.55,3619.66,Race,.dir(S) Turn
-W59,-1611.51,411.29,3678.32,IceBlock,3 Fire Arrows
-W60,-1357.03,479.65,3671.94,IceBlock,3 Fire Arrows
+W58,-1996.60,301.55,3619.66,Race
+W59,-1611.51,411.29,3678.32,IceBlock
+W60,-1357.03,479.65,3671.94,IceBlock
 W61,-4347.89,142.88,3713.18,MatchCactus
 W62,-3031.62,181.00,3754.59,RockCircle
 W63,-2448.41,134.73,3751.93,Race
@@ -813,54 +813,54 @@ W66,-4160.32,133.13,3826.20,LiftRock
 W67,-3286.43,169.88,3787.15,MatchCactus
 W68,-2547.42,141.43,3951.93,LiftRock,On pillar
 X01,-308.77,132.64,-1166.00,LiftRock,On ledge
-X02,-147.51,188.97,-1159.79,LilyPads,No Drown
+X02,-147.51,188.97,-1159.79,LilyPads
 X03,-265.73,250.36,-1138.75,LiftRockRubble
-X04,-378.65,163.60,-1112.09,Balloon,BA BT
-X05,-250.14,432.88,-1061.67,Confetti,Top of Castle
+X04,-378.65,163.60,-1112.09,Balloon
+X05,-250.14,432.88,-1061.67,Confetti,Castle spire
 X06,-251.84,517.16,-1061.77,Balloon
-X07,-383.20,347.46,-993.62,Confetti,Top of Zelda's Study
-X08,-368.95,151.43,-993.44,LiftRock,Wooden Platform
+X07,-383.20,347.46,-993.62,Confetti,Spire of Zelda's Study
+X08,-368.95,151.43,-993.44,LiftRock,On wooden platform
 X09,-335.40,256.56,-1003.31,LiftRock
 X10,-254.0,364.01,-994.61,Race,Glide
 X11,-100.92,131.37,-979.74,IceBlock
 X12,-68.06,261.28,-979.62,LiftRock
 X13,-436.57,117.51,-932.82,OfferEgg
 X14,-270.26,255.10,-879.19,LiftRockRubble
-X15,-168.36,216.01,-860.40,AcornHanging,Inside Room
-X16,-162.05,310.19,-878.05,Confetti,Top of Second Gatehouse
-X17,-353.38,286.36,-829.60,Confetti,Top of First Gatehouse
+X15,-168.36,216.01,-860.40,AcornHanging,Behind wall
+X16,-162.05,310.19,-878.05,Confetti,Spire of Second Gatehouse
+X17,-353.38,286.36,-829.60,Confetti,Spire of First Gatehouse
 X18,-394.02,204.57,-785.40,LiftRock,On wall
-X19,-324.38,185.61,-798.15,AcornHanging,Inside 3AA Room
+X19,-324.38,185.61,-798.15,AcornHanging,Behind wall
 X20,-163.28,156.12,-784.67,LiftRockRubble
 X21,-254.00,210.54,-739.54,ShootEmblem
-X22,-247.16,211.84,-739.61,Balloon,Aim top wall in background
+X22,-247.16,211.84,-739.61,Balloon
 X23,-234.59,233.97,-743.93,Balloon
 X24,-253.85,172.90,-632.22,LiftRock,On gate
 X25,-230.68,148.01,-633.37,FlowerChase,Across bridge
 Z01,4707.05,292.62,-1355.01,FlowerChase
-Z02,1398.03,125.98,-856.34,Race,Ordinal Low
+Z02,1398.03,125.98,-856.34,Race
 Z03,1404.95,122.09,-832.98,LightChase
 Z04,3208.67,570.48,-1011.22,LiftRock
 Z05,3565.88,530.63,-915.92,LightChase
-Z06,4702.88,297.25,-1039.33,LiftRock,Wood Platform
+Z06,4702.88,297.25,-1039.33,LiftRock,On wood platform
 Z07,4698.90,345.46,-1003.02,LiftRock,On pillar
 Z08,3893.50,549.96,-704.23,LiftRockRubble
 Z09,4616.44,366.46,-638.02,LilyPads
 Z10,4697.83,335.70,-547.03,LiftRockRubble
 Z11,1104.01,210.75,-444.23,Balloon,In tree
-Z12,1632.92,119.0,-545.19,LilyPads,Drown
-Z13,1832.72,217.95,-535.69,Race,Ordinal Delay
+Z12,1632.92,119.0,-545.19,LilyPads
+Z13,1832.72,217.95,-535.69,Race
 Z14,2427.76,301.40,-412.12,Confetti,Top of tree
 Z15,2791.46,451.49,-500.93,BlockPuzzle
 Z16,3323.91,301.62,-519.51,Confetti
-Z17,3321.49,414.09,-514.25,Confetti,Top of ZD
+Z17,3321.49,414.09,-514.25,Confetti,Top of Zora's Domain
 Z18,3520.64,326.72,-383.58,BlockPuzzle
-Z19,4071.79,483.77,-459.05,BoulderGolf,Magnesis
+Z19,4071.79,483.77,-459.05,BoulderGolf,Use magnesis
 Z20,4136.60,521.71,-408.56,FlowerChase
 Z21,1088.53,164.78,-215.89,RockCircle,Near water
 Z22,2517.50,182.50,-212.48,LiftRock,On hill
 Z23,2746.14,237.58,-176.40,Well
-Z24,3083.23,363.92,-167.68,FlowerChase,Stay Grounded
+Z24,3083.23,363.92,-167.68,FlowerChase
 Z25,3291.97,295.38,-261.12,LiftRock,On ledge
 Z26,3527.28,395.30,-276.76,LiftRock,Peak
 Z27,4080.40,421.47,-216.78,BlockPuzzle
@@ -873,19 +873,19 @@ Z33,3206.76,312.25,23.68,LightChase
 Z34,3303.74,393.35,22.58,LiftRock,Peak
 Z35,4134.86,294.93,60.32,LiftRockRubble
 Z36,4294.82,171.30,78.50,LiftRockRubble
-Z37,883.07,133.61,274.79,LiftRock,middle of thorns
+Z37,883.07,133.61,274.79,LiftRock,Middle of thorns
 Z38,1434.73,117.50,135.40,Well
 Z39,1593.18,115.98,114.16,LightChase
 Z40,1736.36,129.04,85.67,AcornHanging,From tree
 Z41,2085.78,129.78,181.66,RockCircle
-Z42,2769.94,123.21,348.84,Balloon,Shoot from above
+Z42,2769.94,123.21,348.84,Balloon
 Z43,2927.66,292.94,332.80,BlockPuzzle
 Z44,3140.85,220.79,324.96,LightChase
 Z45,3854.31,150.81,352.25,LightChase
 Z46,4144.43,138.33,195.96,BlockPuzzle
 Z47,1116.14,119.93,555.57,LiftRockBoulder
 Z48,1313.97,115.90,503.06,LightChase
-Z49,1446.49,116.03,558.36,MatchTree,left tree
+Z49,1446.49,116.03,558.36,MatchTree
 Z50,1685.60,129.82,661.12,LightChase
 Z51,3271.14,105.92,656.82,RockCircle
 Z52,3431.14,146.40,523.74,LiftRockLeaves
@@ -898,4 +898,4 @@ Z58,4452.65,164.26,483.97,Balloon,In cave
 Z59,4572.53,134.99,647.89,FlowerChase,Start in forest
 Z60,1595.75,117.39,807.67,OfferApple,In cave
 Z61,4499.12,123.24,1015.01,FlowerChase
-Z62,4533.43,111.22,1022.98,RockCircle,During flower chase
+Z62,4533.43,111.22,1022.98,RockCircle

--- a/packages/celer-code-generator/src/koroks.csv
+++ b/packages/celer-code-generator/src/koroks.csv
@@ -265,7 +265,7 @@ F13,2284.27,287.53,2659.97,LiftRock,Under tree
 F14,2874.91,299.73,2683.36,LilyPads
 F15,1325.56,296.66,3008.67,LightChase
 F16,1562.56,298.62,2898.31,Race
-F17,1773.84,346.68,2930.86,Well
+F17,1773.84,346.68,2930.86,Well,Ball and chain
 F18,3084.93,239.77,2884.64,LiftRockRubble,In cave
 F19,1785.53,344.36,3011.07,Race,Swim up
 F20,1943.74,348.58,3009.42,MatchTree
@@ -641,7 +641,7 @@ R11,-1017.85,116.95,-1066.07,Basketball
 R12,-3109.25,34.17,-909.26,Confetti,Top of flagpole
 R13,-2669.55,375.56,-864.39,LiftRock,Top of waterfall
 R14,-2316.80,206.68,-806.45,LightChase
-R15,-2060.66,259.49,-775.78,RockCircle
+R15,-2060.66,259.49,-775.78,RockCircle,On top of tree
 R16,-1142.41,182.62,-761.94,BlockPuzzle
 R17,-2698.41,414.59,-766.74,LiftRock,Top of mountain
 R18,-1964.67,221.20,-584.16,Race,Run
@@ -855,7 +855,7 @@ Z15,2791.46,451.49,-500.93,BlockPuzzle
 Z16,3323.91,301.62,-519.51,Confetti
 Z17,3321.49,414.09,-514.25,Confetti,Top of Zora's Domain
 Z18,3520.64,326.72,-383.58,BlockPuzzle
-Z19,4071.79,483.77,-459.05,BoulderGolf,Use magnesis
+Z19,4071.79,483.77,-459.05,BoulderGolf,Metal boulder
 Z20,4136.60,521.71,-408.56,FlowerChase
 Z21,1088.53,164.78,-215.89,RockCircle,Near water
 Z22,2517.50,182.50,-212.48,LiftRock,On hill


### PR DESCRIPTION
- Removed strategy advice in comments (like "bullet time," "no drown," use of runes, etc).
- Revised or removed relative directional comments. For example, "left tree" might not be accurate if the korok is later re-routed.
- Some spelling/spacing/style edits.