### PR TITLE
Bug Fix: Korok Module not returning clean ref for koroks with movements

### DIFF
--- a/packages/celer-code-generator/src/Korok.ts
+++ b/packages/celer-code-generator/src/Korok.ts
@@ -68,16 +68,18 @@ class KorokModule implements CompilerPresetModule {
 			timeOverride: mapKorokToEstimate(type),
 
 		});
-
 	}
 
 	private addMovement(id: string, x: number, z: number): void {
-		const korok = this.map[id]();
-		korok.movements?.splice(-1,0,{to: {x, z},
-			isAway: false,
-			isWarp: false
-		});
-		this.map[id] = ()=>korok;
+		const oldGenerator = this.map[id];
+		this.map[id] = ()=>{
+			const korok = oldGenerator();
+			korok.movements?.splice(-1,0,{to: {x, z},
+				isAway: false,
+				isWarp: false
+			});
+			return korok;
+		};
 	}
 
 }

--- a/packages/celer-web-app/CHANGELOG.md
+++ b/packages/celer-web-app/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Change Log
 This is the change log for celer-web-app
 
-## `5.3.0` - `03-31-2023` `LATEST`
+## `5.3.1` - `04-06-2023` `LATEST`
+- Fixed a bug where the korok module doesn't return a clean reference for koroks with movements
+
+## `5.3.0` - `03-31-2023`
 - Fixed the bug where local bundles are not loaded correctly
 - Moved icon resolution to Engine (`Exp.NewIconResolution`). This allows the icons to be resolved in a centralized manner and be available to the rest of the app.
 

--- a/packages/celer-web-app/package.json
+++ b/packages/celer-web-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "celer-web-app",
   "homepage": "https://celer.itntpiston.app",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.16.0",

--- a/packages/celer-web-app/src/core/compiler/modules/Korok.ts
+++ b/packages/celer-web-app/src/core/compiler/modules/Korok.ts
@@ -1303,16 +1303,18 @@ class KorokModule implements CompilerPresetModule {
 			timeOverride: mapKorokToEstimate(type),
 
 		});
-
 	}
 
 	private addMovement(id: string, x: number, z: number): void {
-		const korok = this.map[id]();
-		korok.movements?.splice(-1,0,{to: {x, z},
-			isAway: false,
-			isWarp: false
-		});
-		this.map[id] = ()=>korok;
+		const oldGenerator = this.map[id];
+		this.map[id] = ()=>{
+			const korok = oldGenerator();
+			korok.movements?.splice(-1,0,{to: {x, z},
+				isAway: false,
+				isWarp: false
+			});
+			return korok;
+		};
 	}
 
 }

--- a/packages/celer-web-app/src/data/util/version.ts
+++ b/packages/celer-web-app/src/data/util/version.ts
@@ -1,1 +1,1 @@
-export const WebAppVersion = "5.3.0";
+export const WebAppVersion = "5.3.1";


### PR DESCRIPTION
The recent early icon resolution change requires the icon name on presets to be resolved in the Compiler.
However, since the ref for certain koroks is not clean, the compiler tries to re-resolve the resolved icon, which causes compiler errors to appear.

Fixed by making the korok module return a clean ref